### PR TITLE
Extract install helper into utils.sh and reuse in python installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-# Helper function for install messages
-install() {
-	if pacman -Q $1 &> /dev/null; then
-		echo "$1 - skipped (already installed)"
-	else
-		echo "installing $1 ..."
-		sudo pacman -S --noconfirm $1
-	fi
-}
+source "$(dirname "$0")/utils.sh"
 
 # Git
 install git
@@ -35,6 +27,7 @@ fi
 
 # ssh
 install openssh
+install ksshaskpass
 
 # create default directories
 dirs=(
@@ -99,4 +92,3 @@ install qt6-wayland
 install kitty
 install wl-clipboard
 install polkit-gnome
-

--- a/python_install.sh
+++ b/python_install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source "$(dirname "$0")/utils.sh"
+
+install base-devel
+install openssl
+install zlib
+install xz
+install tk

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Helper function for install messages
+install() {
+	if pacman -Q $1 &> /dev/null; then
+		echo "$1 - skipped (already installed)"
+	else
+		echo "installing $1 ..."
+		sudo pacman -S --noconfirm $1
+	fi
+}


### PR DESCRIPTION
## Summary
- extract the `install()` helper from `install.sh` into a new `utils.sh`
- source `utils.sh` from `install.sh`
- initialize `python_install.sh` to source `utils.sh` and install required Python build deps

## Changes
- add `utils.sh` with shared `install()` function
- update `install.sh` to `source "$(dirname "$0")/utils.sh"`
- update `python_install.sh` with:
  - `install base-devel`
  - `install openssl`
  - `install zlib`
  - `install xz`
  - `install tk`