### PR TITLE
Small bat alias to remove decorations

### DIFF
--- a/config/aliases.zsh
+++ b/config/aliases.zsh
@@ -1,3 +1,4 @@
+alias bat='bat -p'
 alias ls='eza --icons=auto --group-directories-first'
 alias ll='eza --icons=auto --group-directories-first -l'
 alias la='eza --icons=auto --group-directories-first -la'


### PR DESCRIPTION
### Summary
- Added an alias for bat to remove decorations (`bat -p` for plain). This is to make it easier to copy parts of a file; it removes the need to remove line numbers and vertical separators, etc.