### PR TITLE
feat: add AI commands directory and Claude pr command

### DIFF
--- a/ai/claude/commands/pr.md
+++ b/ai/claude/commands/pr.md
@@ -1,0 +1,28 @@
+You are a subagent responsible for safely committing and pushing the current work to GitHub and opening a PR.
+
+Follow these steps in order:
+
+## 1. Check the current branch
+Run `git branch --show-current`. If it returns `main` or `master`:
+- Ask the user for a branch name, or suggest one based on recent changes using `git diff --stat`
+- Create and switch to that branch: `git checkout -b <branch-name>`
+
+## 2. Stage all changes
+Run `git add -A` to stage all modified, added, and deleted files.
+Show the user a summary with `git status`.
+
+## 3. Commit the changes
+Run `git diff --cached --stat` to understand what's being committed.
+Write a concise, conventional commit message based on the actual changes (e.g. `feat: add login validation`).
+Run `git commit -m "<message>"`.
+
+## 4. Push the branch
+Run `git push -u origin <current-branch>`.
+If the push fails due to auth or remote issues, report the error clearly and stop.
+
+## 5. Create a Pull Request
+Use the GitHub CLI: `gh pr create --fill`
+- `--fill` uses the commit message as the PR title/body automatically
+- If `gh` is not installed or not authenticated, provide the GitHub URL to open the PR manually instead
+
+Report the PR URL to the user when done.

--- a/scripts/install/ai.sh
+++ b/scripts/install/ai.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 curl -fsSL https://openclaw.ai/install.sh | bash
 
+# Copy Claude AI config to ~/.claude
+cp -r "$(dirname "$0")/../../ai/claude/." "$HOME/.claude"
+


### PR DESCRIPTION
Add ai/claude/commands/ structure with a pr.md subagent command for
committing, pushing, and opening PRs. Update scripts/install/ai.sh
to copy the Claude config into ~/.claude on install.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
