### PR TITLE
feat: add Claude Code, OpenAI Codex, and Starship installs

### DIFF
--- a/scripts/install/ai.sh
+++ b/scripts/install/ai.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
-curl -fsSL https://openclaw.ai/install.sh | bash
+
+source "$(dirname "$0")/../utils.sh"
+
+# Claude Code
+if check_command claude; then
+    echo "claude - skipped (already installed)"
+else
+    echo "Installing Claude Code ..."
+    npm install -g @anthropic-ai/claude-code
+fi
+
+# OpenAI Codex
+if check_command codex; then
+    echo "codex - skipped (already installed)"
+else
+    echo "Installing OpenAI Codex ..."
+    npm install -g @openai/codex
+fi
 
 # Copy Claude AI config to ~/.claude
 cp -r "$(dirname "$0")/../../ai/claude/." "$HOME/.claude"
-

--- a/scripts/install/terminal-tools.sh
+++ b/scripts/install/terminal-tools.sh
@@ -11,3 +11,4 @@ install eza # ls replacement
 install zoxide
 install unzip
 install zip
+install starship


### PR DESCRIPTION
## Summary
- Rewrote `scripts/install/ai.sh` to install Claude Code (`@anthropic-ai/claude-code`) and OpenAI Codex (`@openai/codex`) via npm, with idempotency checks using `check_command`
- Added `starship` prompt to `scripts/install/terminal-tools.sh` via the existing `install` helper

## Test plan
- [ ] Run `scripts/install/ai.sh` on a fresh system and verify `claude` and `codex` are installed
- [ ] Re-run `scripts/install/ai.sh` and confirm both are skipped as already installed
- [ ] Run `scripts/install/terminal-tools.sh` and verify `starship` installs correctly
- [ ] Re-run and confirm `starship` is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)