### PR TITLE
feat: add uv to python install script

### DIFF
--- a/scripts/install/python.sh
+++ b/scripts/install/python.sh
@@ -7,3 +7,4 @@ install openssl
 install zlib
 install xz
 install tk
+install uv


### PR DESCRIPTION
## Summary
- Adds `uv` (fast Python package manager) to the Python install script alongside existing build dependencies

## Test plan
- [x] Run `bash scripts/install/python.sh` and confirm `uv` installs without errors
- [x] Re-run to verify idempotency (already installed packages are skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)